### PR TITLE
Add Home component and integrate layout navigation

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,10 +2,12 @@ import React, { useState, useEffect } from 'react'
 import Layout from './components/Layout'
 import DiagnoseFlow from './components/DiagnoseFlow'
 import CaseHistory from './components/CaseHistory'
+import Home from './components/Home'
 import { initOfflineStorage } from './utils/offline'
 
 function App() {
   const [currentView, setCurrentView] = useState('home')
+  const [activeTab, setActiveTab] = useState(null)
   const [isOfflineReady, setIsOfflineReady] = useState(false)
 
   useEffect(() => {
@@ -27,14 +29,31 @@ function App() {
 
   const handleStartDiagnosis = () => {
     setCurrentView('diagnose')
+    setActiveTab('diagnose')
   }
 
   const handleViewHistory = () => {
     setCurrentView('history')
+    setActiveTab('history')
   }
 
   const handleBackToHome = () => {
     setCurrentView('home')
+    setActiveTab(null)
+  }
+
+  const handleTabChange = (tab) => {
+    setActiveTab(tab)
+    switch (tab) {
+      case 'diagnose':
+        setCurrentView('diagnose')
+        break
+      case 'history':
+        setCurrentView('history')
+        break
+      default:
+        setCurrentView('home')
+    }
   }
 
   const renderCurrentView = () => {
@@ -44,19 +63,14 @@ function App() {
       case 'history':
         return <CaseHistory onBack={handleBackToHome} />
       default:
-        return (
-          <Layout 
-            onStartDiagnosis={handleStartDiagnosis}
-            onViewHistory={handleViewHistory}
-          />
-        )
+        return <Home onStartDiagnosis={handleStartDiagnosis} onViewHistory={handleViewHistory} />
     }
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-blue-50 to-white">
+    <Layout activeTab={activeTab} setActiveTab={handleTabChange}>
       {renderCurrentView()}
-    </div>
+    </Layout>
   )
 }
 

--- a/frontend/src/components/Home.jsx
+++ b/frontend/src/components/Home.jsx
@@ -1,0 +1,23 @@
+import React from 'react'
+
+function Home({ onStartDiagnosis, onViewHistory }) {
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-blue-50 to-white px-4 py-6 flex flex-col items-center justify-center space-y-4">
+      <h1 className="text-2xl font-bold text-gray-800 mb-8">Dogtor AI</h1>
+      <button
+        onClick={onStartDiagnosis}
+        className="w-full max-w-xs py-3 px-4 bg-blue-600 text-white rounded-xl shadow hover:bg-blue-700 transition-colors"
+      >
+        Start Diagnosis
+      </button>
+      <button
+        onClick={onViewHistory}
+        className="w-full max-w-xs py-3 px-4 bg-white text-blue-600 border border-blue-600 rounded-xl shadow hover:bg-blue-50 transition-colors"
+      >
+        View Case History
+      </button>
+    </div>
+  )
+}
+
+export default Home


### PR DESCRIPTION
## Summary
- create `Home` component with Start Diagnosis and View Case History options
- update `App` to render `Home` on the home view and manage active bottom nav state via `Layout`

## Testing
- `npm test`
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68a25e3e598083278ad05a73db2abbb6