### PR TITLE
refactor: unify navigation using tab layout

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,7 +5,7 @@ import CaseHistory from './components/CaseHistory'
 import { initOfflineStorage } from './utils/offline'
 
 function App() {
-  const [currentView, setCurrentView] = useState('home')
+  const [activeTab, setActiveTab] = useState('diagnose')
   const [isOfflineReady, setIsOfflineReady] = useState(false)
 
   useEffect(() => {
@@ -25,38 +25,23 @@ function App() {
     }
   }, [])
 
-  const handleStartDiagnosis = () => {
-    setCurrentView('diagnose')
-  }
-
-  const handleViewHistory = () => {
-    setCurrentView('history')
-  }
-
-  const handleBackToHome = () => {
-    setCurrentView('home')
-  }
-
-  const renderCurrentView = () => {
-    switch (currentView) {
+  const renderActiveTab = () => {
+    switch (activeTab) {
       case 'diagnose':
-        return <DiagnoseFlow onBack={handleBackToHome} />
+        return <DiagnoseFlow onBack={() => setActiveTab('history')} />
       case 'history':
-        return <CaseHistory onBack={handleBackToHome} />
+        return <CaseHistory onBack={() => setActiveTab('diagnose')} />
+      case 'connect':
+        return <div className="p-4">Connect feature coming soon.</div>
       default:
-        return (
-          <Layout 
-            onStartDiagnosis={handleStartDiagnosis}
-            onViewHistory={handleViewHistory}
-          />
-        )
+        return null
     }
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-blue-50 to-white">
-      {renderCurrentView()}
-    </div>
+    <Layout activeTab={activeTab} setActiveTab={setActiveTab}>
+      {renderActiveTab()}
+    </Layout>
   )
 }
 


### PR DESCRIPTION
## Summary
- consolidate navigation to tab-based layout
- rename `currentView` to `activeTab` and integrate with `Layout`
- add placeholder content for Connect tab

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a25e4a0d5c832797caf4a1e2a47c6b